### PR TITLE
Update data.py

### DIFF
--- a/src/data.py
+++ b/src/data.py
@@ -244,7 +244,7 @@ def worker_rnd_init(x):
 def compile_data(version, dataroot, data_aug_conf, grid_conf, bsz,
                  nworkers, parser_name):
     nusc = NuScenes(version='v1.0-{}'.format(version),
-                    dataroot=os.path.join(dataroot, version),
+                    dataroot=dataroot,
                     verbose=False)
     parser = {
         'vizdata': VizData,


### PR DESCRIPTION
This pull request fixes issue #23.

When downloading the full NuScenes dataset, Motional recommends that all of it is consolidated in one folder with the corresponding `.json` files in the `v1.0-split` folders instead of having the `nuscenes/split/.../v1.0-split` subfolders.

Basically following the folder tree posted in the[ NuScenes Forum](https://forum.nuscenes.org/t/how-to-load-trainval-data/520/2).
